### PR TITLE
Tidy

### DIFF
--- a/mksbom.pl
+++ b/mksbom.pl
@@ -4,84 +4,90 @@ use POSIX qw/strftime setlocale LC_TIME/;
 use JSON;
 use Getopt::Long;
 
-my $url = "https://github.com/msmeissn/rpm-list-to-sbom";
+my $url  = "https://github.com/msmeissn/rpm-list-to-sbom";
 my $name = "unset";
 
-GetOptions ( "url=s" => \$url, "name=s"   => \$name)
-	or die("Error in command line arguments\n");
-
+GetOptions( "url=s" => \$url, "name=s" => \$name )
+  or die("Error in command line arguments\n");
 
 my @output = ();
 
-my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime();
-my $curtime = POSIX::strftime("%Y-%m-%dT%H:%M:%S",$sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst );
+my ( $sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst ) =
+  localtime();
+my $curtime = POSIX::strftime( "%Y-%m-%dT%H:%M:%S",
+    $sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst );
 
 my %map = (
-	"spdxVersion"		=> "SPDX-2.2",
-	"dataLicense"		=> "CC-BY-4.0",
-	"SPDXID"		=> "SPDXRef-DOCUMENT",
-	"name"			=> $name,
-	"documentNamespace"	=> "https://ftp.suse.com/pub/projects/security/spdx/",	# FIXME
-	"CreationInfo" 		=> {
-		"Creators"	=> [ {"Tool" => "https://github.com/msmeissn/rpm-list-to-sbom", } ],
-		"Created"	=> $curtime,
-	},
+    "spdxVersion"       => "SPDX-2.2",
+    "dataLicense"       => "CC-BY-4.0",
+    "SPDXID"            => "SPDXRef-DOCUMENT",
+    "name"              => $name,
+    "documentNamespace" =>
+      "https://ftp.suse.com/pub/projects/security/spdx/",    # FIXME
+    "CreationInfo" => {
+        "Creators" =>
+          [ { "Tool" => "https://github.com/msmeissn/rpm-list-to-sbom", } ],
+        "Created" => $curtime,
+    },
 );
 
-my @describes = ("outputfile");				# FIXME
+my @describes = ("outputfile");    # FIXME
 $map{"documentDescribes"} = \@describes;
-
 
 my @packages = ();
 
 my @rpms = `find . -name "*.rpm"`;
 foreach my $rpm (@rpms) {
-	chomp $rpm;
+    chomp $rpm;
 
-	my $basename = $rpm;
-	$basename =~ s/.*\///;
-	my $rpmname = $basename;
-	$rpmname =~ s/(.*)-([^-]*-[^-]*)$/$1/;
-	my $name = $1;
-	my $version = $2;
+    my $basename = $rpm;
+    $basename =~ s/.*\///;
+    my $rpmname = $basename;
+    $rpmname =~ s/(.*)-([^-]*-[^-]*)$/$1/;
+    my $name    = $1;
+    my $version = $2;
 
-	my $rquery = `rpm -qp --qf '%{LICENSE}|%{URL}|%{SUMMARY}|%{SOURCERPM}\n' $rpm`;
-	chomp $rquery;
-	my ($license,$url,$sourceinfo,$summary) = split (/\|/,$rquery);
+    my $rquery =
+      `rpm -qp --qf '%{LICENSE}|%{URL}|%{SUMMARY}|%{SOURCERPM}\n' $rpm`;
+    chomp $rquery;
+    my ( $license, $url, $sourceinfo, $summary ) = split( /\|/, $rquery );
 
-	my $description = `rpm -qp --qf '%{DESCRIPTION}\n' $rpm`;
-	chomp($description);
+    my $description = `rpm -qp --qf '%{DESCRIPTION}\n' $rpm`;
+    chomp($description);
 
-	#"checksum": { "algorithm": "SHA1", "checksumValue": "14ff98203c3ddd2bd4803c00b5225d2551ca603c" },
-	my $sha2 = `sha256sum $rpm`;
-	chomp($sha2);
-	$sha2 =~ s/ .*//;
+#"checksum": { "algorithm": "SHA1", "checksumValue": "14ff98203c3ddd2bd4803c00b5225d2551ca603c" },
+    my $sha2 = `sha256sum $rpm`;
+    chomp($sha2);
+    $sha2 =~ s/ .*//;
 
-	my %package = (
-		"description"			=> $description,
-		"summary"			=> $summary,
-		"homepage"			=> $url,
-		"packageName"			=> $name, # FIXME ... full version and arch?
-		"packageVersion"		=> $version,
-		"sourceInfo"			=> $sourceinfo,
-		"packageFilename"		=> $basename,
-		"SPDXID" 			=> "SPDXRef-$basename",
-		#"downloadLocation"		=> "$url$rpm",	# FIXME
-		"filesAnalyzed" 		=> "false",
-		"packageLicenseConcluded"	=> $license,
-		"packageLicenseDeclared" 	=> $license,
-		"packageCopyrightText"		=> $license,
-		"checksum"			=> [ {
-			"algorithm" 	=> "SHA256",
-			"checksumValue"	=> $sha2,
-		} ],
-	);
-	push @packages,\%package;
+    my %package = (
+        "description"     => $description,
+        "summary"         => $summary,
+        "homepage"        => $url,
+        "packageName"     => $name,          # FIXME ... full version and arch?
+        "packageVersion"  => $version,
+        "sourceInfo"      => $sourceinfo,
+        "packageFilename" => $basename,
+        "SPDXID"          => "SPDXRef-$basename",
+
+        #"downloadLocation"		=> "$url$rpm",	# FIXME
+        "filesAnalyzed"           => "false",
+        "packageLicenseConcluded" => $license,
+        "packageLicenseDeclared"  => $license,
+        "packageCopyrightText"    => $license,
+        "checksum"                => [
+            {
+                "algorithm"     => "SHA256",
+                "checksumValue" => $sha2,
+            }
+        ],
+    );
+    push @packages, \%package;
 }
 
 $map{"packages"} = \@packages;
 
-# "externalDocumentRefs": [ ? 
-#   "relationships": [ ? 
+# "externalDocumentRefs": [ ?
+#   "relationships": [ ?
 
-print encode_json(\%map);
+print encode_json( \%map );

--- a/mksbom.pl
+++ b/mksbom.pl
@@ -1,14 +1,22 @@
 #!/usr/bin/perl -w
 use strict;
-use POSIX qw/strftime setlocale LC_TIME/;
-use JSON;
+use warnings;
 use Getopt::Long;
+use JSON;
+use POSIX qw/strftime setlocale LC_TIME/;
 
-my $url  = "https://github.com/msmeissn/rpm-list-to-sbom";
-my $name = "unset";
+my $url                = "https://github.com/msmeissn/rpm-list-to-sbom";
+my $name               = "unset";
+my $packageNameIsNEVRA = 0;
 
-GetOptions( "url=s" => \$url, "name=s" => \$name )
-  or die("Error in command line arguments\n");
+GetOptions(
+    "url=s"              => \$url,
+    "name=s"             => \$name,
+    "packageNameIsNEVRA" => \$packageNameIsNEVRA
+) or die("Error in command line arguments\n");
+
+# Ensure $url has a trailing slash
+$url =~ s|/*$|/|;
 
 my @output = ();
 
@@ -36,58 +44,89 @@ $map{"documentDescribes"} = \@describes;
 
 my @packages = ();
 
-my @rpms = `find . -name "*.rpm"`;
-foreach my $rpm (@rpms) {
-    chomp $rpm;
+sub multi_hashes {
+    my ($filename) = @_;
 
-    my $basename = $rpm;
-    $basename =~ s/.*\///;
-    my $rpmname = $basename;
-    $rpmname =~ s/(.*)-([^-]*-[^-]*)$/$1/;
-    my $name    = $1;
-    my $version = $2;
+    # This function reads a named file, chunk-by-chunk,
+    # and simultaneously feeds that data into three Digest functions.
+    # This means that:
+    # - We don't need to read the whole file into RAM
+    # - We only need to read the file once for each kind of digest
+    # - We can easily extend this to more digest types if necessary
+    my %hashers;
 
-    my $rquery =
-      `rpm -qp --qf '%{LICENSE}|%{URL}|%{SUMMARY}|%{SOURCERPM}\n' $rpm`;
-    chomp $rquery;
-    my ( $license, $url, $sourceinfo, $summary ) = split( /\|/, $rquery );
+    # Only use available hashers
+    if ( eval { require Digest::MD5 } ) {
+        $hashers{'MD5'} = Digest::MD5->new;
+    }
+    if ( eval { require Digest::SHA } ) {
+        $hashers{'SHA1'}   = Digest::SHA->new(1);
+        $hashers{'SHA256'} = Digest::SHA->new(256);
+    }
 
-    my $description = `rpm -qp --qf '%{DESCRIPTION}\n' $rpm`;
-    chomp($description);
+    scalar(%hashers) or die "Could not find any Digest::* modules";
 
-#"checksum": { "algorithm": "SHA1", "checksumValue": "14ff98203c3ddd2bd4803c00b5225d2551ca603c" },
-    my $sha2 = `sha256sum $rpm`;
-    chomp($sha2);
-    $sha2 =~ s/ .*//;
+    open my $fh, '<:raw', $filename or die;
 
-    my %package = (
-        "description"     => $description,
-        "summary"         => $summary,
-        "homepage"        => $url,
-        "packageName"     => $name,          # FIXME ... full version and arch?
-        "packageVersion"  => $version,
-        "sourceInfo"      => $sourceinfo,
-        "packageFilename" => $basename,
-        "SPDXID"          => "SPDXRef-$basename",
+    my $data       = "";
+    my $offset     = 0;
+    my $CHUNK_SIZE = 1024 * 1024;    # 1MB
 
-        #"downloadLocation"		=> "$url$rpm",	# FIXME
-        "filesAnalyzed"           => "false",
-        "packageLicenseConcluded" => $license,
-        "packageLicenseDeclared"  => $license,
-        "packageCopyrightText"    => $license,
-        "checksum"                => [
-            {
-                "algorithm"     => "SHA256",
-                "checksumValue" => $sha2,
-            }
-        ],
-    );
-    push @packages, \%package;
+    while (1) {
+        my $success = read $fh, $data, $CHUNK_SIZE, $offset;
+        die $! if not defined $success;
+        last   if not $success;
+
+        # A chunk was successfully read, so push it to the hashers
+        for my $hasher ( keys %hashers ) {
+            $hashers{$hasher}->add($data);
+        }
+
+        # read will append to $data each time, so clear the buffer now
+        $data = "";
+
+        # and increment $offset by how much we actually read
+        $offset += $success;
+    }
+
+    my @output;
+    for my $hasher ( keys %hashers ) {
+        push @output,
+          {
+            "algorithm"     => $hasher,
+            "checksumValue" => $hashers{$hasher}->hexdigest
+          };
+    }
+    return \@output;
+
 }
 
-$map{"packages"} = \@packages;
+my $json = JSON->new;
 
-# "externalDocumentRefs": [ ?
-#   "relationships": [ ?
+foreach my $rpm ( glob("*.rpm") ) {
+
+    my $packageNameMacro = $packageNameIsNEVRA ? "%{NEVRA}" : "%{NAME}";
+
+    # Get the essential data from RPM
+    # FIXME: Can this command line be line-wrapped at all?
+    my $qs =
+qx(rpm -qp \"$rpm\" --queryformat '\\{"description": "%{DESCRIPTION}", "summary": "%{SUMMARY}", "homepage": "%{URL}", "packageName": "${packageNameMacro}", "packageVersion": "%{VERSION}", "sourceInfo": "%{SOURCERPM}", "packageLicenseDeclared": "%{LICENSE}"\\}');
+    $qs =~ s|\n|\\n|g;
+    my $rpm_info = $json->relaxed->decode($qs);
+
+    # Add extra information
+    $rpm_info->{SPDXID}                  = "SPDXRef-$rpm";
+    $rpm_info->{packageFilename}         = "$rpm";
+    $rpm_info->{filesAnalyzed}           = "false";
+    $rpm_info->{packageLicenseConcluded} = $rpm_info->{packageLicenseDeclared};
+    $rpm_info->{packageCopyrightText}    = $rpm_info->{packageLicenseDeclared};
+    $rpm_info->{checksum}                = multi_hashes($rpm);
+    $rpm_info->{downloadLocation}        = "$url$rpm";
+
+    push @packages, $rpm_info;
+}
+
+@{ $map{"packages"} } =
+  sort { $a->{packageFilename} <=> $b->{packageFilename} } @packages;
 
 print encode_json( \%map );


### PR DESCRIPTION
By using JSON in the `rpm --queryformat`, we can just call it once for everything.

Additionally, we can make use of Perl's `Digest::*` modules, and produce multiple hashes at once.